### PR TITLE
feat(model-restriction): restrict agents to configured models only

### DIFF
--- a/docs/agents/configuration.mdx
+++ b/docs/agents/configuration.mdx
@@ -184,6 +184,18 @@ Tool `path` values are resolved relative to the config file's directory, unless 
 | `model` | Yes | Model ID as the provider expects it |
 | `thinkingLevel` | No | `off` \| `minimal` \| `low` \| `medium` \| `high` — extended thinking budget |
 
+### `agents.<name>.fallbackModels`
+
+Optional array of fallback models tried in order when the primary model fails (rate limits, errors).
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `provider` | Yes | Must match a key in `llm.providers` |
+| `model` | Yes | Model ID as the provider expects it |
+| `thinkingLevel` | No | `off` \| `minimal` \| `low` \| `medium` \| `high` |
+
+**Model restriction**: The `model` and `fallbackModels` define the **only** models an agent can use. Users cannot switch to other models via the TUI or API. This ensures predictable behavior and cost control.
+
 ### `agents.<name>.sandbox`
 
 | Field | Required | Description |

--- a/docs/agents/index.mdx
+++ b/docs/agents/index.mdx
@@ -95,6 +95,8 @@ Agents are defined in `config.json5` under `agents`:
 | `skills` | No | Skill names from the skills registry |
 | `sandbox` | No | Docker image, extra host mounts, extra env vars |
 
+**Model Restriction**: The `model` and `fallbackModels` together define the **only** models an agent can use. Users cannot switch to other models via the TUI or API — even if other providers are configured. This ensures predictable behavior and cost control. See [LLM Providers → Model Restriction](/agents/providers#model-restriction) for details.
+
 For provider and model configuration details, see [LLM Providers](/agents/providers). For the complete list of all config fields and their defaults, see the [Config Reference](/agents/configuration).
 
 ---

--- a/docs/agents/providers.mdx
+++ b/docs/agents/providers.mdx
@@ -118,6 +118,14 @@ agents: {
 }
 ```
 
+### Model Restriction {#model-restriction}
+
+The `model` and `fallbackModels` fields define the **only** models an agent can use. Users cannot switch to other models via the TUI or API — even if other providers are configured. This ensures:
+
+- **Predictable behavior** — agents always use known, tested models
+- **Cost control** — no accidental usage of expensive models
+- **Compliance** — enforce model policies per agent
+
 ```mermaid
 flowchart TD
     A[Request arrives] --> B{Primary model<br/>available?}

--- a/src/channels/tui.ts
+++ b/src/channels/tui.ts
@@ -23,6 +23,7 @@ import type { OnToolStart } from "../gateway/agent-manager.js";
 import { SessionSettingsStore, resolveSessionSetting } from "../gateway/session-settings.js";
 import { BeigeSessionStore } from "../gateway/sessions.js";
 import { loadSkills, buildSkillContext, validateSkillDeps, type LoadedSkill } from "../skills/registry.js";
+import { RestrictedModelRegistry, buildAllowedModels } from "../config/restricted-model-registry.js";
 
 /**
  * TUI channel — runs in a separate process and connects to the gateway HTTP API.
@@ -67,7 +68,10 @@ interface TUIState {
   gatewayUrl: string;
   config: BeigeConfig;
   authStorage: AuthStorage;
-  modelRegistry: ModelRegistry;
+  /** Restricted registry that only exposes models allowed for this agent */
+  modelRegistry: RestrictedModelRegistry;
+  /** Underlying unrestricted registry for internal lookups */
+  underlyingModelRegistry: ModelRegistry;
   settingsStore: SessionSettingsStore;
   sessionStore: BeigeSessionStore;
   loadedSkills: Map<string, LoadedSkill>;
@@ -137,6 +141,12 @@ export async function launchTUI(opts: TUIOptions): Promise<void> {
   // ── Load skills ────────────────────────────────────────────
   const loadedSkills = await loadSkills(config);
 
+  // ── Create restricted model registry ──────────────────────
+  // The agent can only use models defined in its config (model + fallbackModels)
+  const agentConfig = config.agents[agentName];
+  const allowedModels = buildAllowedModels(agentConfig.model, agentConfig.fallbackModels);
+  const restrictedModelRegistry = new RestrictedModelRegistry(modelRegistry, allowedModels);
+
   // ── Shared state ──────────────────────────────────────────
   const settingsStore = new SessionSettingsStore();
   const sessionStore = new BeigeSessionStore();
@@ -144,13 +154,14 @@ export async function launchTUI(opts: TUIOptions): Promise<void> {
 
   const state: TUIState = {
     agentName,
-    agentConfig: config.agents[agentName],
+    agentConfig,
     session: null,
     toolStartHandlerRef,
     gatewayUrl,
     config,
     authStorage,
-    modelRegistry,
+    modelRegistry: restrictedModelRegistry,
+    underlyingModelRegistry: modelRegistry,
     settingsStore,
     sessionStore,
     loadedSkills,
@@ -181,6 +192,14 @@ export async function launchTUI(opts: TUIOptions): Promise<void> {
 
   // ── Launch pi TUI ─────────────────────────────────────────
   console.log(`[TUI] Agent: ${agentName} (${state.agentConfig.model.provider}/${state.agentConfig.model.model})`);
+
+  // Show allowed models (for model switching)
+  const availableModels = state.modelRegistry.getAvailable();
+  if (availableModels.length > 1) {
+    const modelList = availableModels.map(m => `${m.provider}/${m.id}`).join(", ");
+    console.log(`[TUI] Allowed models: ${modelList}`);
+  }
+
   console.log(`[TUI] Tools: ${agentInfo.tools.join(", ") || "(core only)"}`);
   console.log(`[TUI] Verbose: ${initialVerbose ? "on" : "off"} — use /beige-verbose on|off to toggle`);
   console.log(`[TUI] Commands: /beige-new, /beige-resume, /beige-sessions, /beige-agent <name>, /beige-verbose on|off (or /v on|off)`);
@@ -198,7 +217,7 @@ export async function launchTUI(opts: TUIOptions): Promise<void> {
  * Create a new pi session for the current agent in state.
  */
 async function createSession(state: TUIState, extensionsResult: LoadExtensionsResult): Promise<void> {
-  const { agentName, agentConfig, gatewayUrl, authStorage, modelRegistry, toolStartHandlerRef, loadedSkills } = state;
+  const { agentName, agentConfig, gatewayUrl, authStorage, modelRegistry, underlyingModelRegistry, toolStartHandlerRef, loadedSkills } = state;
 
   // Fetch agent info from gateway
   const agentsRes = await fetch(`${gatewayUrl}/api/agents`);
@@ -210,7 +229,8 @@ async function createSession(state: TUIState, extensionsResult: LoadExtensionsRe
   // Validate skill dependencies
   validateSkillDeps(skillNames, toolNames, loadedSkills);
 
-  const model = resolveModel(agentConfig, modelRegistry);
+  // Use underlying registry for model lookup (restricted registry delegates find())
+  const model = resolveModel(agentConfig, underlyingModelRegistry);
   const coreTools = createProxyTools(agentName, gatewayUrl, toolStartHandlerRef);
   const toolContext = buildToolContext(toolNames);
   const skillContext = buildSkillContext(skillNames, loadedSkills);
@@ -245,8 +265,13 @@ async function createSession(state: TUIState, extensionsResult: LoadExtensionsRe
     }),
     resourceLoader,
     authStorage,
-    modelRegistry,
+    // Pass underlying registry for session creation
+    modelRegistry: modelRegistry.getUnderlying(),
   });
+
+  // Replace the session's modelRegistry with our restricted version
+  // This ensures the TUI's model switcher only shows allowed models
+  (session as any)._modelRegistry = modelRegistry;
 
   state.session = session;
 }
@@ -297,7 +322,8 @@ async function buildBeigeExtension(
     const sessionManager = SessionManager.create(process.cwd(), sessionsDir);
 
     const resourceLoader = await buildResourceLoader(state);
-    const model = resolveModel(state.agentConfig, state.modelRegistry);
+    // Use underlying registry for model lookup
+    const model = resolveModel(state.agentConfig, state.underlyingModelRegistry);
     const coreTools = createProxyTools(state.agentName, state.gatewayUrl, state.toolStartHandlerRef);
 
     const { session } = await createAgentSession({
@@ -312,8 +338,12 @@ async function buildBeigeExtension(
       }),
       resourceLoader,
       authStorage: state.authStorage,
-      modelRegistry: state.modelRegistry,
+      // Pass underlying registry for session creation
+      modelRegistry: state.modelRegistry.getUnderlying(),
     });
+
+    // Replace the session's modelRegistry with our restricted version
+    (session as any)._modelRegistry = state.modelRegistry;
 
     state.session = session;
     ctx.ui.notify("🆕 New session started.", "info");
@@ -379,7 +409,8 @@ async function buildBeigeExtension(
     // Resume the selected session
     const sessionManager = SessionManager.open(targetSession.file);
     const resourceLoader = await buildResourceLoader(state);
-    const model = resolveModel(state.agentConfig, state.modelRegistry);
+    // Use underlying registry for model lookup
+    const model = resolveModel(state.agentConfig, state.underlyingModelRegistry);
     const coreTools = createProxyTools(state.agentName, state.gatewayUrl, state.toolStartHandlerRef);
 
     const { session } = await createAgentSession({
@@ -394,8 +425,12 @@ async function buildBeigeExtension(
       }),
       resourceLoader,
       authStorage: state.authStorage,
-      modelRegistry: state.modelRegistry,
+      // Pass underlying registry for session creation
+      modelRegistry: state.modelRegistry.getUnderlying(),
     });
+
+    // Replace the session's modelRegistry with our restricted version
+    (session as any)._modelRegistry = state.modelRegistry;
 
     state.session = session;
     ctx.ui.notify(`📂 Resumed session: ${basename(targetSession.file)}`, "info");
@@ -441,6 +476,10 @@ async function buildBeigeExtension(
     // Update state
     state.agentName = arg;
     state.agentConfig = newAgentConfig;
+
+    // Update restricted model registry for new agent's allowed models
+    const allowedModels = buildAllowedModels(newAgentConfig.model, newAgentConfig.fallbackModels);
+    state.modelRegistry = new RestrictedModelRegistry(state.underlyingModelRegistry, allowedModels);
 
     // Create new session for the new agent
     const extensionsResult = await buildBeigeExtension(state, availableAgents);
@@ -723,7 +762,7 @@ ${skillContext}
 `;
 }
 
-function resolveModel(agentConfig: AgentConfig, modelRegistry: ModelRegistry) {
+function resolveModel(agentConfig: AgentConfig, modelRegistry: ModelRegistry | RestrictedModelRegistry) {
   const { provider, model: modelId } = agentConfig.model;
   const model = getModel(provider as any, modelId);
   if (model) return model;

--- a/src/config/restricted-model-registry.spec.ts
+++ b/src/config/restricted-model-registry.spec.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import { RestrictedModelRegistry, buildAllowedModels, validateModelAllowed } from "./restricted-model-registry.js";
+import { ModelRegistry, AuthStorage } from "@mariozechner/pi-coding-agent";
+import type { Model, Api } from "@mariozechner/pi-ai";
+
+describe("RestrictedModelRegistry", () => {
+  // Create a mock model
+  const createMockModel = (provider: string, id: string): Model<Api> => ({
+    provider,
+    id,
+    name: `${provider}/${id}`,
+    contextWindow: 100000,
+    maxTokens: 4096,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    api: "anthropic-messages" as Api,
+    baseUrl: `https://api.${provider}.com`,
+  });
+
+  // Create a mock underlying registry
+  const createMockRegistry = (models: Model<Api>[]): Partial<ModelRegistry> => {
+    return {
+      getAvailable: () => models,
+      find: (provider: string, modelId: string) =>
+        models.find((m) => m.provider === provider && m.id === modelId),
+      getAll: () => models,
+    };
+  };
+
+  it("filters getAvailable() to only allowed models", () => {
+    const allModels = [
+      createMockModel("anthropic", "claude-sonnet-4"),
+      createMockModel("anthropic", "claude-3-5-sonnet"),
+      createMockModel("openai", "gpt-4"),
+    ];
+
+    const mockRegistry = createMockRegistry(allModels) as ModelRegistry;
+    const allowedModels = [
+      { provider: "anthropic", modelId: "claude-sonnet-4" },
+      { provider: "openai", modelId: "gpt-4" },
+    ];
+
+    const restricted = new RestrictedModelRegistry(mockRegistry, allowedModels);
+    const available = restricted.getAvailable();
+
+    expect(available).toHaveLength(2);
+    expect(available.map((m) => `${m.provider}/${m.id}`).sort()).toEqual([
+      "anthropic/claude-sonnet-4",
+      "openai/gpt-4",
+    ]);
+  });
+
+  it("returns empty array when no models are available", () => {
+    const mockRegistry = createMockRegistry([]) as ModelRegistry;
+    const allowedModels = [{ provider: "anthropic", modelId: "claude-sonnet-4" }];
+
+    const restricted = new RestrictedModelRegistry(mockRegistry, allowedModels);
+    const available = restricted.getAvailable();
+
+    expect(available).toHaveLength(0);
+  });
+
+  it("excludes models not in allowed list even if available", () => {
+    const allModels = [
+      createMockModel("anthropic", "claude-sonnet-4"),
+      createMockModel("openai", "gpt-4"),
+    ];
+
+    const mockRegistry = createMockRegistry(allModels) as ModelRegistry;
+    const allowedModels = [{ provider: "anthropic", modelId: "claude-sonnet-4" }];
+
+    const restricted = new RestrictedModelRegistry(mockRegistry, allowedModels);
+    const available = restricted.getAvailable();
+
+    expect(available).toHaveLength(1);
+    expect(available[0].id).toBe("claude-sonnet-4");
+  });
+
+  it("delegates find() to underlying registry", () => {
+    const allModels = [createMockModel("anthropic", "claude-sonnet-4")];
+    const mockRegistry = createMockRegistry(allModels) as ModelRegistry;
+    const restricted = new RestrictedModelRegistry(mockRegistry, []);
+
+    const found = restricted.find("anthropic", "claude-sonnet-4");
+    expect(found?.id).toBe("claude-sonnet-4");
+  });
+
+  it("delegates getAll() to underlying registry", () => {
+    const allModels = [
+      createMockModel("anthropic", "claude-sonnet-4"),
+      createMockModel("openai", "gpt-4"),
+    ];
+    const mockRegistry = createMockRegistry(allModels) as ModelRegistry;
+    const restricted = new RestrictedModelRegistry(mockRegistry, []);
+
+    const all = restricted.getAll();
+    expect(all).toHaveLength(2);
+  });
+
+  it("getUnderlying() returns the original registry", () => {
+    const mockRegistry = createMockRegistry([]) as ModelRegistry;
+    const restricted = new RestrictedModelRegistry(mockRegistry, []);
+
+    expect(restricted.getUnderlying()).toBe(mockRegistry);
+  });
+});
+
+describe("buildAllowedModels", () => {
+  it("builds list from primary model only", () => {
+    const model = { provider: "anthropic", model: "claude-sonnet-4" };
+    const allowed = buildAllowedModels(model);
+
+    expect(allowed).toEqual([{ provider: "anthropic", modelId: "claude-sonnet-4" }]);
+  });
+
+  it("includes fallback models in order", () => {
+    const model = { provider: "anthropic", model: "claude-sonnet-4" };
+    const fallbackModels = [
+      { provider: "anthropic", model: "claude-3-5-sonnet" },
+      { provider: "openai", model: "gpt-4" },
+    ];
+
+    const allowed = buildAllowedModels(model, fallbackModels);
+
+    expect(allowed).toEqual([
+      { provider: "anthropic", modelId: "claude-sonnet-4" },
+      { provider: "anthropic", modelId: "claude-3-5-sonnet" },
+      { provider: "openai", modelId: "gpt-4" },
+    ]);
+  });
+
+  it("handles empty fallbackModels array", () => {
+    const model = { provider: "anthropic", model: "claude-sonnet-4" };
+    const allowed = buildAllowedModels(model, []);
+
+    expect(allowed).toHaveLength(1);
+  });
+});
+
+describe("validateModelAllowed", () => {
+  it("does not throw for allowed model", () => {
+    const allowedModels = [
+      { provider: "anthropic", modelId: "claude-sonnet-4" },
+      { provider: "openai", modelId: "gpt-4" },
+    ];
+
+    expect(() => validateModelAllowed("anthropic", "claude-sonnet-4", allowedModels)).not.toThrow();
+    expect(() => validateModelAllowed("openai", "gpt-4", allowedModels)).not.toThrow();
+  });
+
+  it("throws for non-allowed model", () => {
+    const allowedModels = [{ provider: "anthropic", modelId: "claude-sonnet-4" }];
+
+    expect(() => validateModelAllowed("openai", "gpt-4", allowedModels)).toThrow(
+      "Model openai/gpt-4 is not allowed for this agent"
+    );
+  });
+
+  it("includes allowed models in error message", () => {
+    const allowedModels = [
+      { provider: "anthropic", modelId: "claude-sonnet-4" },
+      { provider: "anthropic", modelId: "claude-3-5-sonnet" },
+    ];
+
+    try {
+      validateModelAllowed("openai", "gpt-4", allowedModels);
+      expect.fail("Should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      const message = (error as Error).message;
+      expect(message).toContain("anthropic/claude-sonnet-4");
+      expect(message).toContain("anthropic/claude-3-5-sonnet");
+    }
+  });
+});

--- a/src/config/restricted-model-registry.ts
+++ b/src/config/restricted-model-registry.ts
@@ -1,0 +1,149 @@
+/**
+ * Restricted model registry wrapper.
+ *
+ * Wraps a ModelRegistry and restricts `getAvailable()` to only return models
+ * that are in the agent's allowed list (model + fallbackModels).
+ *
+ * This prevents users from switching to models not configured for the agent
+ * via the TUI's model switching features (Ctrl+P, /model, etc.).
+ */
+
+import type { Model, Api } from "@mariozechner/pi-ai";
+import { ModelRegistry, type AuthStorage } from "@mariozechner/pi-coding-agent";
+import type { ModelRef } from "./schema.js";
+
+/**
+ * A restricted model registry that only exposes allowed models.
+ *
+ * Wraps the real ModelRegistry but filters getAvailable() to only return
+ * models that match the agent's configured model and fallbackModels.
+ *
+ * All other methods delegate to the underlying registry.
+ *
+ * Note: This class implements the same interface as ModelRegistry but
+ * uses composition instead of inheritance (ModelRegistry has private fields).
+ * Use `as unknown as ModelRegistry` when passing to APIs that expect ModelRegistry.
+ */
+export class RestrictedModelRegistry {
+  private underlying: ModelRegistry;
+  private allowedModels: Array<{ provider: string; modelId: string }>;
+
+  constructor(
+    underlying: ModelRegistry,
+    allowedModels: Array<{ provider: string; modelId: string }>
+  ) {
+    this.underlying = underlying;
+    this.allowedModels = allowedModels;
+  }
+
+  /**
+   * Get only models that are both available (have auth) AND in the allowed list.
+   */
+  getAvailable(): Model<Api>[] {
+    const allAvailable = this.underlying.getAvailable();
+    return allAvailable.filter((model) =>
+      this.allowedModels.some(
+        (allowed) => allowed.provider === model.provider && allowed.modelId === model.id
+      )
+    );
+  }
+
+  // Delegate all other ModelRegistry methods
+
+  get authStorage(): AuthStorage {
+    return this.underlying.authStorage;
+  }
+
+  refresh(): void {
+    return this.underlying.refresh();
+  }
+
+  getError(): string | undefined {
+    return this.underlying.getError();
+  }
+
+  getAll(): Model<Api>[] {
+    return this.underlying.getAll();
+  }
+
+  find(provider: string, modelId: string): Model<Api> | undefined {
+    return this.underlying.find(provider, modelId);
+  }
+
+  async getApiKey(model: Model<Api>): Promise<string | undefined> {
+    return this.underlying.getApiKey(model);
+  }
+
+  async getApiKeyForProvider(provider: string): Promise<string | undefined> {
+    return this.underlying.getApiKeyForProvider(provider);
+  }
+
+  isUsingOAuth(model: Model<Api>): boolean {
+    return this.underlying.isUsingOAuth(model);
+  }
+
+  registerProvider(providerName: string, config: Parameters<ModelRegistry["registerProvider"]>[1]): void {
+    return this.underlying.registerProvider(providerName, config);
+  }
+
+  unregisterProvider(providerName: string): void {
+    return this.underlying.unregisterProvider(providerName);
+  }
+
+  /**
+   * Get the underlying unrestricted registry.
+   * Use this when you need to pass a real ModelRegistry to APIs.
+   */
+  getUnderlying(): ModelRegistry {
+    return this.underlying;
+  }
+
+  /**
+   * Cast to ModelRegistry for use with APIs that expect ModelRegistry.
+   * Safe because this class implements the same interface.
+   */
+  asModelRegistry(): ModelRegistry {
+    return this.underlying;
+  }
+}
+
+/**
+ * Build the list of allowed models from an agent's model configuration.
+ */
+export function buildAllowedModels(model: ModelRef, fallbackModels?: ModelRef[]): Array<{ provider: string; modelId: string }> {
+  const allowed: Array<{ provider: string; modelId: string }> = [
+    { provider: model.provider, modelId: model.model },
+  ];
+
+  if (fallbackModels) {
+    for (const fallback of fallbackModels) {
+      allowed.push({ provider: fallback.provider, modelId: fallback.model });
+    }
+  }
+
+  return allowed;
+}
+
+/**
+ * Validate that a model is in the allowed list.
+ * Throws an error if the model is not allowed.
+ */
+export function validateModelAllowed(
+  provider: string,
+  modelId: string,
+  allowedModels: Array<{ provider: string; modelId: string }>
+): void {
+  const isAllowed = allowedModels.some(
+    (m) => m.provider === provider && m.modelId === modelId
+  );
+
+  if (!isAllowed) {
+    const allowedList = allowedModels
+      .map((m) => `${m.provider}/${m.modelId}`)
+      .join(", ");
+    throw new Error(
+      `Model ${provider}/${modelId} is not allowed for this agent. ` +
+      `Allowed models: ${allowedList}`
+    );
+  }
+}

--- a/src/gateway/agent-manager.ts
+++ b/src/gateway/agent-manager.ts
@@ -21,6 +21,7 @@ import { buildSkillContext, validateSkillDeps, type LoadedSkill } from "../skill
 import { ProviderHealthTracker, extractRateLimitInfo } from "./provider-health.js";
 import { parseSessionKey, type SessionContext } from "../types/session.js";
 import { beigeDir } from "../paths.js";
+import { validateModelAllowed } from "../config/restricted-model-registry.js";
 
 /**
  * Callback fired by the gateway when the agent is about to execute a tool.
@@ -476,6 +477,15 @@ export class AgentManager {
       await this.disposeSession(sessionKey);
     }
 
+    const agentConfig = this.config.agents[agentName];
+    if (!agentConfig) {
+      throw new Error(`Unknown agent: ${agentName}`);
+    }
+
+    // Validate that the requested model is allowed for this agent
+    const allowedModels = this.getAllowedModels(agentConfig);
+    validateModelAllowed(modelRef.provider, modelRef.model, allowedModels);
+
     // Check if we need to recreate the session with a different model
     const existing = this.sessions.get(sessionKey);
 
@@ -494,11 +504,6 @@ export class AgentManager {
       );
       existing.session.dispose();
       this.sessions.delete(sessionKey);
-    }
-
-    const agentConfig = this.config.agents[agentName];
-    if (!agentConfig) {
-      throw new Error(`Unknown agent: ${agentName}`);
     }
 
     // Determine session file
@@ -691,6 +696,23 @@ export class AgentManager {
     const custom = this.modelRegistry.find(provider, modelId);
     if (custom) return custom;
     throw new Error(`Model not found: ${provider}/${modelId}. Check your config and API keys.`);
+  }
+
+  /**
+   * Build the list of allowed models for an agent.
+   */
+  private getAllowedModels(agentConfig: AgentConfig): Array<{ provider: string; modelId: string }> {
+    const allowed: Array<{ provider: string; modelId: string }> = [
+      { provider: agentConfig.model.provider, modelId: agentConfig.model.model },
+    ];
+
+    if (agentConfig.fallbackModels) {
+      for (const fallback of agentConfig.fallbackModels) {
+        allowed.push({ provider: fallback.provider, modelId: fallback.model });
+      }
+    }
+
+    return allowed;
   }
 }
 

--- a/src/gateway/api.ts
+++ b/src/gateway/api.ts
@@ -83,6 +83,7 @@ export class GatewayAPI {
         const agents = Object.entries(this.opts.config.agents).map(([name, config]) => ({
           name,
           model: config.model,
+          fallbackModels: config.fallbackModels ?? [],
           tools: config.tools,
           skills: config.skills ?? [],
         }));


### PR DESCRIPTION
## Summary

Implements model restriction for agents so that `model` and `fallbackModels` define the **only** models an agent can use. Users cannot switch to other models via the TUI or API — even if other providers are configured.

## Changes

### Core Implementation
- **New file: `src/config/restricted-model-registry.ts`**
  - `RestrictedModelRegistry` class - wraps a `ModelRegistry` and filters `getAvailable()` to only return allowed models
  - `buildAllowedModels()` helper - builds the list of allowed models from agent config
  - `validateModelAllowed()` helper - validates a model is in the allowed list, throws descriptive error if not

- **Updated `src/channels/tui.ts`**
  - Added `RestrictedModelRegistry` to wrap the model registry
  - Monkey-patches `session._modelRegistry` after session creation so pi's TUI model switcher only shows allowed models
  - Shows "Allowed models" in startup output when there are multiple
  - Updates the restricted registry when switching agents via `/beige-agent`

- **Updated `src/gateway/agent-manager.ts`**
  - Added validation in `getOrCreateSessionWithModel()` to ensure requested model is allowed
  - Added `getAllowedModels()` helper method
  - Blocks any attempt to use a disallowed model at the gateway level

- **Updated `src/gateway/api.ts`**
  - Added `fallbackModels` to the `GET /api/agents` response

### Tests
- **New test file: `src/config/restricted-model-registry.spec.ts`**
  - 12 tests covering the restricted registry, buildAllowedModels, and validateModelAllowed

### Documentation
- **`docs/agents/configuration.mdx`** - Added `fallbackModels` field reference and model restriction note
- **`docs/agents/index.mdx`** - Added Model Restriction note under Configuration Fields table
- **`docs/agents/providers.mdx`** - Added new `### Model Restriction` subsection with anchor ID

## How It Works

- **TUI**: The model switcher (Ctrl+P) only shows models in the allowed list
- **Gateway**: Any attempt to use a disallowed model is blocked with a clear error message
- **API**: The `/api/agents` endpoint returns the full list of allowed models for each agent

## Benefits

- **Predictable behavior** — agents always use known, tested models
- **Cost control** — no accidental usage of expensive models
- **Compliance** — enforce model policies per agent

## Test Plan

- [x] All 329 tests pass
- [x] TypeScript compiles without errors
- [x] New tests cover restricted registry behavior
